### PR TITLE
Add support for using yaml config to create graphs

### DIFF
--- a/configs/basic_config.yaml
+++ b/configs/basic_config.yaml
@@ -1,0 +1,78 @@
+nodes:
+  - name: A
+    loop:
+      period: 10
+      callback:
+        type: loop
+        publish:
+          - topic: topic1
+            value_range: [0, 10]
+            delay_range: [0, 2]
+  - name: B
+    subscribe:
+      - topic: topic1
+        valid_range: [0, 10]
+        watchdog: 2
+        nominal_callback:
+          type: nominal
+          publish:
+            - topic: topic2
+              value_range: [1, 10]
+              delay_range: [0, 2]
+        invalid_input_callback:
+          type: invalid
+          publish:
+            - topic: topic2
+              value_range: [10, 20]
+              delay_range: [0, 2]
+        lost_input_callback:
+          type: lost
+          publish:
+            - topic: topic2
+              value_range: [20, 30]
+              delay_range: [0, 2]
+  - name: C
+    subscribe:
+      - topic: topic1
+        valid_range: [0, 10]
+        watchdog: 2
+        nominal_callback:
+          type: nominal
+          publish:
+            - topic: topic3
+              value_range: [1, 10]
+              delay_range: [0, 2]
+        invalid_input_callback:
+          type: invalid
+          publish:
+            - topic: topic3
+              value_range: [10, 20]
+              delay_range: [0, 2]
+        lost_input_callback:
+          type: lost
+          publish:
+            - topic: topic3
+              value_range: [20, 30]
+              delay_range: [0, 2]
+  - name: D
+    subscribe:
+      - topic: topic2
+        valid_range: [0, 10]
+        watchdog: 2
+        nominal_callback:
+          type: nominal
+        invalid_input_callback:
+          type: invalid
+        lost_input_callback:
+          type: lost
+  - name: E
+    subscribe:
+      - topic: topic3
+        valid_range: [0, 10]
+        watchdog: 2
+        nominal_callback:
+          type: nominal
+        invalid_input_callback:
+          type: invalid
+        lost_input_callback:
+          type: lost

--- a/graph_generator/main.py
+++ b/graph_generator/main.py
@@ -33,6 +33,7 @@ def main():
         nodes = load_config('~/graph_generator/configs/basic_config.yaml')
     except LoadConfigError as e:
         print(f"Error: {e}")
+        exit(1)
 
     graph = Graph()
     for node in nodes:

--- a/graph_generator/main.py
+++ b/graph_generator/main.py
@@ -8,6 +8,7 @@ from graph_generator.fault_injection import (
 )
 from graph_generator.graph import Graph
 from graph_generator.node import (
+    CallbackConfig,
     InvalidInputCallbackConfig,
     LoopCallbackConfig,
     LoopConfig,
@@ -18,7 +19,60 @@ from graph_generator.node import (
     PublishConfig,
     SubscriptionConfig,
 )
+import os
+import yaml
+from typing import List, Tuple, Union
 
+use_yaml = True
+
+class LoadConfigError(Exception):
+    pass
+
+def construct_publish_config(data: dict) -> PublishConfig:
+    data["value_range"] = tuple(data["value_range"])
+    data["delay_range"] = tuple(data["delay_range"])
+    return PublishConfig(**data)
+
+def construct_callback_config(data: dict) -> CallbackConfig:
+    if "publish" in data:
+        data["publish"] = [construct_publish_config(pub) for pub in data["publish"]]
+    callback_type = data.pop("type", None)
+    if callback_type == "nominal":
+        return NominalCallbackConfig(**data)
+    elif callback_type == "invalid":
+        return InvalidInputCallbackConfig(**data)
+    elif callback_type == "lost":
+        return LostInputCallbackConfig(**data)
+    elif callback_type == "loop":
+        return LoopCallbackConfig(**data)
+    else:
+        raise LoadConfigError(f"Unsupported callback type: {callback_type}")
+    return CallbackConfig(**data)
+
+def construct_subscription_config(data: dict) -> SubscriptionConfig:
+    data["valid_range"] = tuple(data["valid_range"])
+    data["nominal_callback"] = construct_callback_config(data["nominal_callback"])
+    data["invalid_input_callback"] = construct_callback_config(data["invalid_input_callback"])
+    data["lost_input_callback"] = construct_callback_config(data["lost_input_callback"])
+    return SubscriptionConfig(**data)
+
+def construct_node_config(data: dict) -> NodeConfig:
+    if "loop" in data:
+        data["loop"]["callback"] = construct_callback_config(data["loop"]["callback"])
+        data["loop"] = LoopConfig(**data["loop"])
+    if "subscribe" in data:
+        data["subscribe"] = [construct_subscription_config(sub) for sub in data["subscribe"]]
+    return NodeConfig(**data)
+
+def load_config(file_path: str) -> List[NodeConfig]:
+    expanded_path = os.path.expanduser(file_path)
+    if not os.path.isfile(expanded_path):
+        raise LoadConfigError(f"Configuration file not found: {expanded_path}")
+    with open(expanded_path, 'r') as file:
+        config_data = yaml.safe_load(file)
+        if "nodes" not in config_data:
+            raise LoadConfigError("Missing 'nodes' key in configuration file")
+        return [construct_node_config(node) for node in config_data["nodes"]]
 
 def main():
     """
@@ -28,138 +82,144 @@ def main():
    /     \
   D       E
     """
-    node_a = NodeConfig(
-        name="A",
-        loop=LoopConfig(
-            period=10,
-            callback=LoopCallbackConfig(
-                publish=[
-                    PublishConfig(
-                        topic="topic1", value_range=(0, 10), delay_range=(0, 2)
-                    )
-                ]
+    if use_yaml:
+        print("Using yaml")
+        try:
+            nodes = load_config('~/graph_generator/configs/basic_config.yaml')
+        except LoadConfigError as e:
+            print(f"Error: {e}")
+    else:
+        print("Using nodeconfig directly")
+        node_a = NodeConfig(
+            name="A",
+            loop=LoopConfig(
+                period=10,
+                callback=LoopCallbackConfig(
+                    publish=[
+                        PublishConfig(
+                            topic="topic1", value_range=(0, 10), delay_range=(0, 2)
+                        )
+                    ]
+                ),
             ),
-        ),
-    )
-    node_b = NodeConfig(
-        name="B",
-        subscribe=[
-            SubscriptionConfig(
-                topic="topic1",
-                valid_range=(0, 10),
-                watchdog=2,
-                nominal_callback=NominalCallbackConfig(
-                    publish=[
-                        PublishConfig(
-                            topic="topic2", value_range=(1, 10), delay_range=(0, 2)
-                        )
-                    ]
-                ),
-                invalid_input_callback=InvalidInputCallbackConfig(
-                    publish=[
-                        PublishConfig(
-                            topic="topic2", value_range=(10, 20), delay_range=(0, 2)
-                        )
-                    ]
-                ),
-                lost_input_callback=LostInputCallbackConfig(
-                    publish=[
-                        PublishConfig(
-                            topic="topic2", value_range=(20, 30), delay_range=(0, 2)
-                        )
-                    ]
-                ),
-            )
-        ],
-    )
-    node_c = NodeConfig(
-        name="C",
-        subscribe=[
-            SubscriptionConfig(
-                topic="topic1",
-                valid_range=(0, 10),
-                watchdog=2,
-                nominal_callback=NominalCallbackConfig(
-                    publish=[
-                        PublishConfig(
-                            topic="topic3", value_range=(1, 10), delay_range=(0, 2)
-                        )
-                    ]
-                ),
-                invalid_input_callback=InvalidInputCallbackConfig(
-                    publish=[
-                        PublishConfig(
-                            topic="topic3", value_range=(10, 20), delay_range=(0, 2)
-                        )
-                    ]
-                ),
-                lost_input_callback=LostInputCallbackConfig(
-                    publish=[
-                        PublishConfig(
-                            topic="topic3", value_range=(20, 30), delay_range=(0, 2)
-                        )
-                    ]
-                ),
-            )
-        ],
-    )
-    node_d = NodeConfig(
-        name="D",
-        subscribe=[
-            SubscriptionConfig(
-                topic="topic2",
-                valid_range=(0, 10),
-                watchdog=2,
-                nominal_callback=NominalCallbackConfig(),
-                invalid_input_callback=InvalidInputCallbackConfig(),
-                lost_input_callback=LostInputCallbackConfig(),
-            )
-        ],
-    )
-    node_e = NodeConfig(
-        name="E",
-        subscribe=[
-            SubscriptionConfig(
-                topic="topic3",
-                valid_range=(0, 10),
-                watchdog=2,
-                nominal_callback=NominalCallbackConfig(),
-                invalid_input_callback=InvalidInputCallbackConfig(),
-                lost_input_callback=LostInputCallbackConfig(),
-            )
-        ],
-    )
-    graph = Graph()
-    graph.add_node(Node(node_a))
-    graph.add_node(Node(node_b))
-    graph.add_node(Node(node_c))
-    graph.add_node(Node(node_d))
-    graph.add_node(Node(node_e))
-    graph.build_graph()
-    print(graph.adjacency_list)
-
-    for fault_injection_config in [
-        FaultInjectionConfig(
-            inject_to="A", inject_at=20, affect_loop=DelayLoopConfig(delay=20)
-        ),
-        FaultInjectionConfig(
-            inject_to="B",
-            inject_at=20,
-            affect_receive=DropReceiveConfig(topic="topic1", times=3),
-        ),
-        FaultInjectionConfig(
-            inject_to="B",
-            inject_at=20,
-            affect_receive=DelayReceiveConfig(topic="topic1", delay=3),
-        ),
-        FaultInjectionConfig(
-            inject_to="A", inject_at=20, affect_loop=DropLoopConfig(times=3)
-        ),
-    ]:
-        executor = Executor(
-            graph=graph, stop_at=50, fault_injection_config=fault_injection_config
         )
-        executor.start(viz=False)
+        node_b = NodeConfig(
+            name="B",
+            subscribe=[
+                SubscriptionConfig(
+                    topic="topic1",
+                    valid_range=(0, 10),
+                    watchdog=2,
+                    nominal_callback=NominalCallbackConfig(
+                        publish=[
+                            PublishConfig(
+                                topic="topic2", value_range=(1, 10), delay_range=(0, 2)
+                            )
+                        ]
+                    ),
+                    invalid_input_callback=InvalidInputCallbackConfig(
+                        publish=[
+                            PublishConfig(
+                                topic="topic2", value_range=(10, 20), delay_range=(0, 2)
+                            )
+                        ]
+                    ),
+                    lost_input_callback=LostInputCallbackConfig(
+                        publish=[
+                            PublishConfig(
+                                topic="topic2", value_range=(20, 30), delay_range=(0, 2)
+                            )
+                        ]
+                    ),
+                )
+            ],
+        )
+        node_c = NodeConfig(
+            name="C",
+            subscribe=[
+                SubscriptionConfig(
+                    topic="topic1",
+                    valid_range=(0, 10),
+                    watchdog=2,
+                    nominal_callback=NominalCallbackConfig(
+                        publish=[
+                            PublishConfig(
+                                topic="topic3", value_range=(1, 10), delay_range=(0, 2)
+                            )
+                        ]
+                    ),
+                    invalid_input_callback=InvalidInputCallbackConfig(
+                        publish=[
+                            PublishConfig(
+                                topic="topic3", value_range=(10, 20), delay_range=(0, 2)
+                            )
+                        ]
+                    ),
+                    lost_input_callback=LostInputCallbackConfig(
+                        publish=[
+                            PublishConfig(
+                                topic="topic3", value_range=(20, 30), delay_range=(0, 2)
+                            )
+                        ]
+                    ),
+                )
+            ],
+        )
+        node_d = NodeConfig(
+            name="D",
+            subscribe=[
+                SubscriptionConfig(
+                    topic="topic2",
+                    valid_range=(0, 10),
+                    watchdog=2,
+                    nominal_callback=NominalCallbackConfig(),
+                    invalid_input_callback=InvalidInputCallbackConfig(),
+                    lost_input_callback=LostInputCallbackConfig(),
+                )
+            ],
+        )
+        node_e = NodeConfig(
+            name="E",
+            subscribe=[
+                SubscriptionConfig(
+                    topic="topic3",
+                    valid_range=(0, 10),
+                    watchdog=2,
+                    nominal_callback=NominalCallbackConfig(),
+                    invalid_input_callback=InvalidInputCallbackConfig(),
+                    lost_input_callback=LostInputCallbackConfig(),
+                )
+            ],
+        )
+        nodes = [node_a, node_b, node_c, node_d, node_e]
+    graph = Graph()
+    for node in nodes:
+        graph.add_node(Node(node))
+        print(node)
+    graph.build_graph()
+
+    # for fault_injection_config in [
+    #     FaultInjectionConfig(
+    #         inject_to="A", inject_at=20, affect_loop=DelayLoopConfig(delay=20)
+    #     ),
+    #     FaultInjectionConfig(
+    #         inject_to="B",
+    #         inject_at=20,
+    #         affect_receive=DropReceiveConfig(topic="topic1", times=3),
+    #     ),
+    #     FaultInjectionConfig(
+    #         inject_to="B",
+    #         inject_at=20,
+    #         affect_receive=DelayReceiveConfig(topic="topic1", delay=3),
+    #     ),
+    #     FaultInjectionConfig(
+    #         inject_to="A", inject_at=20, affect_loop=DropLoopConfig(times=3)
+    #     ),
+    # ]:
+    #     executor = Executor(
+    #         graph=graph, stop_at=50, fault_injection_config=fault_injection_config
+    #     )
+    #     executor.start(viz=False)
 
 
 if __name__ == "__main__":

--- a/graph_generator/main.py
+++ b/graph_generator/main.py
@@ -8,8 +8,8 @@ from graph_generator.fault_injection import (
 )
 from graph_generator.graph import Graph
 from graph_generator.node import (
-    CallbackConfig,
     InvalidInputCallbackConfig,
+    load_config,
     LoopCallbackConfig,
     LoopConfig,
     LostInputCallbackConfig,
@@ -19,207 +19,48 @@ from graph_generator.node import (
     PublishConfig,
     SubscriptionConfig,
 )
-import os
-import yaml
-from typing import List, Tuple, Union
-
-use_yaml = True
-
-class LoadConfigError(Exception):
-    pass
-
-def construct_publish_config(data: dict) -> PublishConfig:
-    data["value_range"] = tuple(data["value_range"])
-    data["delay_range"] = tuple(data["delay_range"])
-    return PublishConfig(**data)
-
-def construct_callback_config(data: dict) -> CallbackConfig:
-    if "publish" in data:
-        data["publish"] = [construct_publish_config(pub) for pub in data["publish"]]
-    callback_type = data.pop("type", None)
-    if callback_type == "nominal":
-        return NominalCallbackConfig(**data)
-    elif callback_type == "invalid":
-        return InvalidInputCallbackConfig(**data)
-    elif callback_type == "lost":
-        return LostInputCallbackConfig(**data)
-    elif callback_type == "loop":
-        return LoopCallbackConfig(**data)
-    else:
-        raise LoadConfigError(f"Unsupported callback type: {callback_type}")
-    return CallbackConfig(**data)
-
-def construct_subscription_config(data: dict) -> SubscriptionConfig:
-    data["valid_range"] = tuple(data["valid_range"])
-    data["nominal_callback"] = construct_callback_config(data["nominal_callback"])
-    data["invalid_input_callback"] = construct_callback_config(data["invalid_input_callback"])
-    data["lost_input_callback"] = construct_callback_config(data["lost_input_callback"])
-    return SubscriptionConfig(**data)
-
-def construct_node_config(data: dict) -> NodeConfig:
-    if "loop" in data:
-        data["loop"]["callback"] = construct_callback_config(data["loop"]["callback"])
-        data["loop"] = LoopConfig(**data["loop"])
-    if "subscribe" in data:
-        data["subscribe"] = [construct_subscription_config(sub) for sub in data["subscribe"]]
-    return NodeConfig(**data)
-
-def load_config(file_path: str) -> List[NodeConfig]:
-    expanded_path = os.path.expanduser(file_path)
-    if not os.path.isfile(expanded_path):
-        raise LoadConfigError(f"Configuration file not found: {expanded_path}")
-    with open(expanded_path, 'r') as file:
-        config_data = yaml.safe_load(file)
-        if "nodes" not in config_data:
-            raise LoadConfigError("Missing 'nodes' key in configuration file")
-        return [construct_node_config(node) for node in config_data["nodes"]]
 
 def main():
     """
+    Using basic_config.yaml:
       A
      / \
     B   C
    /     \
   D       E
     """
-    if use_yaml:
-        print("Using yaml")
-        try:
-            nodes = load_config('~/graph_generator/configs/basic_config.yaml')
-        except LoadConfigError as e:
-            print(f"Error: {e}")
-    else:
-        print("Using nodeconfig directly")
-        node_a = NodeConfig(
-            name="A",
-            loop=LoopConfig(
-                period=10,
-                callback=LoopCallbackConfig(
-                    publish=[
-                        PublishConfig(
-                            topic="topic1", value_range=(0, 10), delay_range=(0, 2)
-                        )
-                    ]
-                ),
-            ),
-        )
-        node_b = NodeConfig(
-            name="B",
-            subscribe=[
-                SubscriptionConfig(
-                    topic="topic1",
-                    valid_range=(0, 10),
-                    watchdog=2,
-                    nominal_callback=NominalCallbackConfig(
-                        publish=[
-                            PublishConfig(
-                                topic="topic2", value_range=(1, 10), delay_range=(0, 2)
-                            )
-                        ]
-                    ),
-                    invalid_input_callback=InvalidInputCallbackConfig(
-                        publish=[
-                            PublishConfig(
-                                topic="topic2", value_range=(10, 20), delay_range=(0, 2)
-                            )
-                        ]
-                    ),
-                    lost_input_callback=LostInputCallbackConfig(
-                        publish=[
-                            PublishConfig(
-                                topic="topic2", value_range=(20, 30), delay_range=(0, 2)
-                            )
-                        ]
-                    ),
-                )
-            ],
-        )
-        node_c = NodeConfig(
-            name="C",
-            subscribe=[
-                SubscriptionConfig(
-                    topic="topic1",
-                    valid_range=(0, 10),
-                    watchdog=2,
-                    nominal_callback=NominalCallbackConfig(
-                        publish=[
-                            PublishConfig(
-                                topic="topic3", value_range=(1, 10), delay_range=(0, 2)
-                            )
-                        ]
-                    ),
-                    invalid_input_callback=InvalidInputCallbackConfig(
-                        publish=[
-                            PublishConfig(
-                                topic="topic3", value_range=(10, 20), delay_range=(0, 2)
-                            )
-                        ]
-                    ),
-                    lost_input_callback=LostInputCallbackConfig(
-                        publish=[
-                            PublishConfig(
-                                topic="topic3", value_range=(20, 30), delay_range=(0, 2)
-                            )
-                        ]
-                    ),
-                )
-            ],
-        )
-        node_d = NodeConfig(
-            name="D",
-            subscribe=[
-                SubscriptionConfig(
-                    topic="topic2",
-                    valid_range=(0, 10),
-                    watchdog=2,
-                    nominal_callback=NominalCallbackConfig(),
-                    invalid_input_callback=InvalidInputCallbackConfig(),
-                    lost_input_callback=LostInputCallbackConfig(),
-                )
-            ],
-        )
-        node_e = NodeConfig(
-            name="E",
-            subscribe=[
-                SubscriptionConfig(
-                    topic="topic3",
-                    valid_range=(0, 10),
-                    watchdog=2,
-                    nominal_callback=NominalCallbackConfig(),
-                    invalid_input_callback=InvalidInputCallbackConfig(),
-                    lost_input_callback=LostInputCallbackConfig(),
-                )
-            ],
-        )
-        nodes = [node_a, node_b, node_c, node_d, node_e]
+    try:
+        nodes = load_config('~/graph_generator/configs/basic_config.yaml')
+    except LoadConfigError as e:
+        print(f"Error: {e}")
+
     graph = Graph()
     for node in nodes:
         graph.add_node(Node(node))
-        print(node)
     graph.build_graph()
 
-    # for fault_injection_config in [
-    #     FaultInjectionConfig(
-    #         inject_to="A", inject_at=20, affect_loop=DelayLoopConfig(delay=20)
-    #     ),
-    #     FaultInjectionConfig(
-    #         inject_to="B",
-    #         inject_at=20,
-    #         affect_receive=DropReceiveConfig(topic="topic1", times=3),
-    #     ),
-    #     FaultInjectionConfig(
-    #         inject_to="B",
-    #         inject_at=20,
-    #         affect_receive=DelayReceiveConfig(topic="topic1", delay=3),
-    #     ),
-    #     FaultInjectionConfig(
-    #         inject_to="A", inject_at=20, affect_loop=DropLoopConfig(times=3)
-    #     ),
-    # ]:
-    #     executor = Executor(
-    #         graph=graph, stop_at=50, fault_injection_config=fault_injection_config
-    #     )
-    #     executor.start(viz=False)
+    for fault_injection_config in [
+        FaultInjectionConfig(
+            inject_to="A", inject_at=20, affect_loop=DelayLoopConfig(delay=20)
+        ),
+        FaultInjectionConfig(
+            inject_to="B",
+            inject_at=20,
+            affect_receive=DropReceiveConfig(topic="topic1", times=3),
+        ),
+        FaultInjectionConfig(
+            inject_to="B",
+            inject_at=20,
+            affect_receive=DelayReceiveConfig(topic="topic1", delay=3),
+        ),
+        FaultInjectionConfig(
+            inject_to="A", inject_at=20, affect_loop=DropLoopConfig(times=3)
+        ),
+    ]:
+        executor = Executor(
+            graph=graph, stop_at=50, fault_injection_config=fault_injection_config
+        )
+        executor.start(viz=False)
 
 
 if __name__ == "__main__":

--- a/graph_generator/main.py
+++ b/graph_generator/main.py
@@ -9,7 +9,6 @@ from graph_generator.fault_injection import (
 from graph_generator.graph import Graph
 from graph_generator.node import (
     InvalidInputCallbackConfig,
-    load_config,
     LoopCallbackConfig,
     LoopConfig,
     LostInputCallbackConfig,
@@ -18,7 +17,9 @@ from graph_generator.node import (
     NominalCallbackConfig,
     PublishConfig,
     SubscriptionConfig,
+    load_config,
 )
+
 
 def main():
     """
@@ -30,7 +31,7 @@ def main():
   D       E
     """
     try:
-        nodes = load_config('~/graph_generator/configs/basic_config.yaml')
+        nodes = load_config("~/graph_generator/configs/basic_config.yaml")
     except LoadConfigError as e:
         print(f"Error: {e}")
         exit(1)

--- a/graph_generator/node.py
+++ b/graph_generator/node.py
@@ -58,7 +58,7 @@ class SubscriptionConfig:
     inputs from upstream.
     A watchdog is a mechanism for nodes to report faults when it hasn't heard from this
     topic for watchdog time units since last receive.
-    If the message is not received within watchdog time, the lost_input_callback wil be
+    If the message is not received within watchdog time, the lost_input_callback will be
     executed. This is useful to simulate handling dropped or delayed messages from upstream.
     """
 

--- a/graph_generator/node.py
+++ b/graph_generator/node.py
@@ -1,8 +1,9 @@
+import os
 from collections import defaultdict
 from dataclasses import dataclass
 from enum import Enum, auto
-import os
 from typing import Any, List, Tuple
+
 import yaml
 
 from graph_generator.fault_injection import (
@@ -246,6 +247,8 @@ class Node:
 Load YAML configuration files and construct the appropriate configuration 
 objects for nodes, callbacks, and publishing in a messaging system.
 """
+
+
 class LoadConfigError(Exception):
     pass
 
@@ -282,7 +285,9 @@ def construct_callback_config(data: dict) -> CallbackConfig:
 def construct_subscription_config(data: dict) -> SubscriptionConfig:
     data["valid_range"] = convert_to_tuple(data["valid_range"])
     data["nominal_callback"] = construct_callback_config(data["nominal_callback"])
-    data["invalid_input_callback"] = construct_callback_config(data["invalid_input_callback"])
+    data["invalid_input_callback"] = construct_callback_config(
+        data["invalid_input_callback"]
+    )
     data["lost_input_callback"] = construct_callback_config(data["lost_input_callback"])
     return SubscriptionConfig(**data)
 
@@ -292,7 +297,9 @@ def construct_node_config(data: dict) -> NodeConfig:
         data["loop"]["callback"] = construct_callback_config(data["loop"]["callback"])
         data["loop"] = LoopConfig(**data["loop"])
     if "subscribe" in data:
-        data["subscribe"] = [construct_subscription_config(sub) for sub in data["subscribe"]]
+        data["subscribe"] = [
+            construct_subscription_config(sub) for sub in data["subscribe"]
+        ]
     return NodeConfig(**data)
 
 
@@ -300,7 +307,7 @@ def load_config(file_path: str) -> List[NodeConfig]:
     expanded_path = os.path.expanduser(file_path)
     if not os.path.isfile(expanded_path):
         raise LoadConfigError(f"Configuration file not found: {expanded_path}")
-    with open(expanded_path, 'r') as file:
+    with open(expanded_path, "r") as file:
         config_data = yaml.safe_load(file)
         if "nodes" not in config_data:
             raise LoadConfigError("Missing 'nodes' key in configuration file")

--- a/graph_generator/node.py
+++ b/graph_generator/node.py
@@ -312,3 +312,4 @@ def load_config(file_path: str) -> List[NodeConfig]:
         if "nodes" not in config_data:
             raise LoadConfigError("Missing 'nodes' key in configuration file")
         return [construct_node_config(node) for node in config_data["nodes"]]
+

--- a/graph_generator/node.py
+++ b/graph_generator/node.py
@@ -312,4 +312,3 @@ def load_config(file_path: str) -> List[NodeConfig]:
         if "nodes" not in config_data:
             raise LoadConfigError("Missing 'nodes' key in configuration file")
         return [construct_node_config(node) for node in config_data["nodes"]]
-

--- a/graph_generator/node.py
+++ b/graph_generator/node.py
@@ -250,9 +250,15 @@ class LoadConfigError(Exception):
     pass
 
 
+def convert_to_tuple(data: List[int]) -> Tuple[int, int]:
+    if not isinstance(data, list) or len(data) != 2:
+        raise LoadConfigError(f"Expected a list of two integers, got: {data}")
+    return tuple(data)
+
+
 def construct_publish_config(data: dict) -> PublishConfig:
-    data["value_range"] = tuple(data["value_range"])
-    data["delay_range"] = tuple(data["delay_range"])
+    data["value_range"] = convert_to_tuple(data["value_range"])
+    data["delay_range"] = convert_to_tuple(data["delay_range"])
     return PublishConfig(**data)
 
 
@@ -274,7 +280,7 @@ def construct_callback_config(data: dict) -> CallbackConfig:
 
 
 def construct_subscription_config(data: dict) -> SubscriptionConfig:
-    data["valid_range"] = tuple(data["valid_range"])
+    data["valid_range"] = convert_to_tuple(data["valid_range"])
     data["nominal_callback"] = construct_callback_config(data["nominal_callback"])
     data["invalid_input_callback"] = construct_callback_config(data["invalid_input_callback"])
     data["lost_input_callback"] = construct_callback_config(data["lost_input_callback"])


### PR DESCRIPTION
- Add a new subfolder called `configs` to house yaml files. Currently populated with yaml file for graph example that was in `main.py`
- Add functions in `node.py` to load a yaml and construct `Node` objects from the config