### PR TITLE
[feature] update how output feature is represented

### DIFF
--- a/graph_generator/node.py
+++ b/graph_generator/node.py
@@ -130,14 +130,15 @@ class NodeConfig(BaseModel):
 
 class NodeFeatureTemplate:
     class FeatureIndex(Enum):
+        LAST_EVENT_TIMESTAMP = 0
         # static features (constant based on node config):
-        NODE_NAME = 0
+        NODE_NAME = auto()
         NUM_SUBSCRIPTIONS = auto()
         NUM_PUBLICATIONS = auto()
         LOOP_PERIOD = auto()
 
         # dynamic features (changes at runtime)
-        LAST_EVENT_TIMESTAMP = auto()
+
         LAST_EVENT_TYPE = auto()
         CALLBACK_TYPE = auto()
         LOOP_COUNT = auto()


### PR DESCRIPTION
Originally each line of the feature output file correponds to the entire graph's node features. This leads to lots of duplication when only a single node's feature changes.

This PR changes each line to only output a single feature that was changed. It's up to users to decide how to parse the features.

Also, updated the feature template to output timestamp first.
example output:
```
0,A,0,1,10,0,0,0,0,0
0,B,1,3,0,0,0,0,0,0
0,C,1,3,0,0,0,0,0,0
0,D,1,0,0,0,0,0,0,0
0,E,1,0,0,0,0,0,0,0
0,A,0,1,10,2,0,1,0,1
0,C,1,3,0,3,2,0,1,1
0,E,1,0,0,3,0,0,1,0
2,B,1,3,0,3,2,0,1,1
2,D,1,0,0,3,0,0,1,0
10,A,0,1,10,2,0,2,0,2
10,C,1,3,0,3,2,0,2,2
12,B,1,3,0,3,2,0,2,2
12,E,1,0,0,3,0,0,2,0
14,D,1,0,0,3,0,0,2,0
20,A,0,1,10,2,0,3,0,3
21,B,1,3,0,3,2,0,3,3
21,C,1,3,0,3,2,0,3,3
21,D,1,0,0,3,0,0,3,0
21,E,1,0,0,3,0,0,3,0
30,A,0,1,10,2,0,4,0,4
31,C,1,3,0,3,2,0,4,4
32,B,1,3,0,3,2,0,4,4
32,E,1,0,0,3,0,0,4,0
34,D,1,0,0,3,0,0,4,0
40,A,0,1,10,2,0,5,0,5
40,C,1,3,0,3,2,0,5,5
41,E,1,0,0,3,0,0,5,0
42,B,1,3,0,3,2,0,5,5
44,D,1,0,0,3,0,0,5,0
```